### PR TITLE
fatal error PDO not found

### DIFF
--- a/codebase/Dhtmlx/Connector/DataStorage/PDODBDataWrapper.php
+++ b/codebase/Dhtmlx/Connector/DataStorage/PDODBDataWrapper.php
@@ -31,7 +31,7 @@ class PDODBDataWrapper extends DBDataWrapper {
 		if ($where) $sql.=" WHERE ".$where;
 		if ($sort) $sql.=" ORDER BY ".$sort;
 		if ($start || $count) {
-			if ($this->connection->getAttribute(PDO::ATTR_DRIVER_NAME)=="pgsql")
+			if ($this->connection->getAttribute(\PDO::ATTR_DRIVER_NAME)=="pgsql")
 				$sql.=" OFFSET ".$start." LIMIT ".$count;
 			else
 				$sql.=" LIMIT ".$start.",".$count;

--- a/codebase/Dhtmlx/Connector/DataStorage/ResultHandler/PDOResultHandler.php
+++ b/codebase/Dhtmlx/Connector/DataStorage/ResultHandler/PDOResultHandler.php
@@ -7,7 +7,7 @@ class PDOResultHandler {
 		$this->res = $res;
 	}
 	public function next(){
-		$data = $this->res->fetch(PDO::FETCH_ASSOC);
+		$data = $this->res->fetch(\PDO::FETCH_ASSOC);
 		if (!$data){
 			$this->res->closeCursor();
 			return null;


### PR DESCRIPTION
Fatal Error
Class 'Dhtmlx\Connector\DataStorage\PDO' not found

Classes and interfaces without a backslash \ inside their
fully-qualified name (for example, the built-in PHP Exception class)
must be fully qualified when used in a namespaced file: for example new
\Exception();.