### PR TITLE
Apply filters for updates

### DIFF
--- a/codebase/update.php
+++ b/codebase/update.php
@@ -223,7 +223,7 @@ class DataUpdate{
 		$output = $this->render_set($this->sql->select($sub_request), $this->item_class);
         
 		ob_clean();
-		header("Content-type:text/xml; charset=".$this->encoding;);
+		header("Content-type:text/xml; charset=".$this->encoding);
 
 		echo $this->updates_start();
 		echo $this->get_version();


### PR DESCRIPTION
Fixed issue when user set the filters for select needed data, something like this
$grid->filter("item_nm", "member");
but  this restrictions not applied for updates.