### PR TITLE
minor regressions in db_mysql and db_mysqli data wrappers

### DIFF
--- a/codebase/db_mysql.php
+++ b/codebase/db_mysql.php
@@ -2,6 +2,8 @@
 
 /*! Implementation of DataWrapper for MySQL
 **/
+require_once("db_common.php");
+
 class MySQLDBDataWrapper extends DBDataWrapper{
 	protected $last_result;
 	public function query($sql){

--- a/codebase/db_mysqli.php
+++ b/codebase/db_mysqli.php
@@ -3,7 +3,7 @@
 	@author dhtmlx.com
 	@license GPL, see license.txt
 */
-require_once("db_common.php");
+require_once("db_mysql.php");
 
 class MySQLiDBDataWrapper extends MySQLDBDataWrapper{
 


### PR DESCRIPTION
1) https://github.com/AlexKlimenkov/connector-php/commit/02475360b56051210307b8bd592e8c73b4d003ac MySQLi wrapper must import MySQL wrapper explicitly since it's no longer included in db_common.php
how to reproduce the issue:
```
require_once('./connector-php/codebase/scheduler_connector.php');
require_once ("./connector-php/codebase/db_mysqli.php");
```
--> Fatal error:Class 'MySQLDBDataWrapper' not found in .../db_mysqli.php on line 8

2) https://github.com/AlexKlimenkov/connector-php/commit/cdf333fe2521697ffb7c91c6a5deb9be9ca2e4ea MySQL wrapper use classes defined in db_common.php but does not import them.  It causes the error If db_mysql.php is included before connector. The error didn't happen in previous versions, other wrappers include db_common explicitly.
how to reproduce:
```
// include db_mysql.php before connector.php
require_once ('./connector-php-my/codebase/db_mysql.php'); 
require_once('./connector-php-my/codebase/scheduler_connector.php');
```
--> Fatal error: Class 'DBDataWrapper' not found in .../db_mysql.php 